### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<spring-cloud.version>Finchley.RELEASE</spring-cloud.version>
 		<mybatis.version>1.3.2</mybatis.version>
 		<jwt.version>0.9.0</jwt.version>
-		<fastjson.version>1.2.47</fastjson.version>
+		<fastjson.version>1.2.83</fastjson.version>
 		<commons-collections>4.1</commons-collections>
 		<monitor.version>2.0.1</monitor.version>
 		<swagger.version>2.8.0</swagger.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alibaba:fastjson 1.2.47
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)


### What did I do？
Upgrade com.alibaba:fastjson from 1.2.47 to 1.2.83 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS